### PR TITLE
SRW-10: Create `<ProfileHeader />`

### DIFF
--- a/components/ProfileHeader/ProfileHeader.test.js
+++ b/components/ProfileHeader/ProfileHeader.test.js
@@ -1,0 +1,16 @@
+import { stubbedRender } from '@/testUtils';
+import ProfileHeader from './ProfileHeader';
+
+describe('<ProfileHeader />', () => {
+  it('should render without crashing', () => {
+    const { unmount } = stubbedRender(ProfileHeader);
+
+    unmount();
+  });
+
+  it('renders correctly', () => {
+    const { container } = stubbedRender(ProfileHeader);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/components/ProfileHeader/ProfileHeader.vue
+++ b/components/ProfileHeader/ProfileHeader.vue
@@ -1,0 +1,158 @@
+<template>
+  <div class="profile-header">
+    <div class="profile-banner"></div>
+    <div class="profile-info-container">
+      <div class="profile-info">
+        <div class="profile-info--header">
+          <div class="profile-info--user-activity">
+            <p><span class="font-semibold">Runs: </span>{{ runCount }}</p>
+            <p><span class="font-semibold">Games: </span>{{ gameCount }}</p>
+          </div>
+          <div class="profile-info--picture-container">
+            <img src="https://via.placeholder.com/120" alt="profile picture" />
+          </div>
+          <div class="profile-info--user-badges">
+            <CoreUserBadges bagdes="badges" />
+          </div>
+        </div>
+        <div class="profile-info--user-bio">
+          <h1 class="text-2xl font-semibold">{{ username }}</h1>
+          <h2 class="text-sm text-black text-opacity-50">{{ location }}</h2>
+          <p class="text-black text-opacity-50 py-2">{{ bio }}</p>
+        </div>
+        <CoreFollowButton />
+        <div class="profile-info--socials">
+          <CoreSocialButtons socials="socials" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from '@nuxtjs/composition-api';
+
+export default defineComponent({
+  props: {
+    badges: {
+      default: () => [],
+      type: Array,
+    },
+    banner: {
+      desktop: {
+        default: '',
+        type: String,
+      },
+      mobile: {
+        default: '',
+        type: String,
+      },
+    },
+    bio: {
+      default: () =>
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget dapibus libero. Morbi ultricies varius accumsan.',
+      type: String,
+    },
+    gameCount: {
+      default: () => 6,
+      type: Number,
+    },
+    location: {
+      default: () => 'Olympus Mons, Mars',
+      type: String,
+    },
+    profile: {
+      desktop: {
+        default: '',
+        type: String,
+      },
+      mobile: {
+        default: '',
+        type: String,
+      },
+    },
+    runCount: {
+      default: () => 42,
+      type: Number,
+    },
+    socials: {
+      default: () => [],
+      type: Array,
+    },
+    username: {
+      default: () => 'JohnSmithRuns',
+      type: String,
+    },
+  },
+});
+</script>
+
+<style scoped>
+.profile-header {
+  height: 450px;
+  max-height: 450px;
+  position: relative;
+
+  @apply flex flex-col;
+  @apply max-w-screen-sm;
+  @apply border border-current;
+}
+
+.profile-banner {
+  height: 50%;
+  min-height: 50%;
+
+  @apply bg-cover bg-center bg-gray-900;
+}
+
+.profile-info-container {
+  position: absolute;
+  @apply bg-transparent;
+  @apply m-5 mb-0;
+}
+
+.profile-info {
+  margin-top: 60px;
+
+  @apply bg-white;
+  @apply grid grid-cols-1;
+  @apply border border-current rounded;
+}
+
+.profile-info--header {
+  @apply grid grid-rows-1 grid-cols-3 relative;
+}
+
+.profile-info--picture-container {
+  @apply relative;
+}
+
+.profile-info--picture-container > img {
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.15));
+  max-height: 120px;
+  max-width: 120px;
+
+  @media screen(md) {
+    max-height: 82px;
+    max-width: 82px;
+  }
+
+  @apply absolute transform -translate-y-1/2;
+  @apply rounded;
+}
+
+.profile-info--user-activity,
+.profile-info--user-badges {
+  @apply p-4;
+}
+
+.profile-info--user-bio {
+  @apply row-span-2;
+  @apply px-4;
+  @apply text-center;
+}
+
+.follow-button {
+  @apply mx-4;
+}
+</style>

--- a/components/ProfileHeader/ProfileHeader.vue
+++ b/components/ProfileHeader/ProfileHeader.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="profile-header">
-    <div class="profile-banner"></div>
+    <div class="profile-banner">
+      <img src="https://via.placeholder.com/885x120" alt="profile banner" />
+    </div>
     <div class="profile-info-container">
       <div class="profile-info">
         <div class="profile-info--header">
@@ -18,11 +20,13 @@
         <div class="profile-info--user-bio">
           <h1 class="text-2xl font-semibold">{{ username }}</h1>
           <h2 class="text-sm text-black text-opacity-50">{{ location }}</h2>
-          <p class="text-black text-opacity-50 py-2">{{ bio }}</p>
+          <p class="text-black text-opacity-50 pt-2">{{ bio }}</p>
         </div>
-        <CoreFollowButton />
+        <div class="profile-info--follow">
+          <CoreFollowButton :badges="badges" />
+        </div>
         <div class="profile-info--socials">
-          <CoreSocialButtons socials="socials" />
+          <CoreSocialButtons :socials="socials" />
         </div>
       </div>
     </div>
@@ -38,16 +42,6 @@ export default defineComponent({
       default: () => [],
       type: Array,
     },
-    banner: {
-      desktop: {
-        default: '',
-        type: String,
-      },
-      mobile: {
-        default: '',
-        type: String,
-      },
-    },
     bio: {
       default: () =>
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget dapibus libero. Morbi ultricies varius accumsan.',
@@ -61,22 +55,33 @@ export default defineComponent({
       default: () => 'Olympus Mons, Mars',
       type: String,
     },
-    profile: {
-      desktop: {
-        default: '',
-        type: String,
-      },
-      mobile: {
-        default: '',
-        type: String,
-      },
-    },
     runCount: {
       default: () => 42,
       type: Number,
     },
     socials: {
-      default: () => [],
+      default: () => [
+        {
+          icon: 'twtr',
+          name: 'Twitter',
+          url: 'https://twitter.com/',
+        },
+        {
+          icon: 'twtr',
+          name: 'Twitter',
+          url: 'https://twitter.com/',
+        },
+        {
+          icon: 'twtr',
+          name: 'Twitter',
+          url: 'https://twitter.com/',
+        },
+        {
+          icon: 'twtr',
+          name: 'Twitter',
+          url: 'https://twitter.com/',
+        },
+      ],
       type: Array,
     },
     username: {
@@ -89,8 +94,8 @@ export default defineComponent({
 
 <style scoped>
 .profile-header {
-  height: 450px;
-  max-height: 450px;
+  height: fit-content;
+  min-height: 450px;
   position: relative;
 
   @apply flex flex-col;
@@ -103,6 +108,11 @@ export default defineComponent({
   min-height: 50%;
 
   @apply bg-cover bg-center bg-gray-900;
+  @apply flex items-center justify-center overflow-x-hidden;
+}
+
+.profile-banner > img {
+  @apply flex-shrink-0 object-cover min-h-full min-w-full;
 }
 
 .profile-info-container {
@@ -116,7 +126,7 @@ export default defineComponent({
 
   @apply bg-white;
   @apply grid grid-cols-1;
-  @apply border border-current rounded;
+  @apply border border-gray-300 rounded;
 }
 
 .profile-info--header {
@@ -141,6 +151,15 @@ export default defineComponent({
   @apply rounded;
 }
 
+.profile-info--socials {
+  @apply p-4 pt-0;
+}
+
+.profile-info--follow > .follow-button {
+  @apply w-full;
+}
+
+.profile-info--follow,
 .profile-info--user-activity,
 .profile-info--user-badges {
   @apply p-4;
@@ -150,9 +169,5 @@ export default defineComponent({
   @apply row-span-2;
   @apply px-4;
   @apply text-center;
-}
-
-.follow-button {
-  @apply mx-4;
 }
 </style>

--- a/components/ProfileHeader/ProfileHeader.vue
+++ b/components/ProfileHeader/ProfileHeader.vue
@@ -6,26 +6,30 @@
     <div class="profile-info-container">
       <div class="profile-info">
         <div class="profile-info--header">
-          <div class="profile-info--user-activity">
+          <div class="profile-info--user-activity md:hidden">
             <p><span class="font-semibold">Runs: </span>{{ runCount }}</p>
             <p><span class="font-semibold">Games: </span>{{ gameCount }}</p>
           </div>
           <div class="profile-info--picture-container">
             <img src="https://via.placeholder.com/120" alt="profile picture" />
           </div>
-          <div class="profile-info--user-badges">
-            <CoreUserBadges bagdes="badges" />
+          <div class="profile-info--user-badges md:hidden">
+            <CoreUserBadges :badges="badges" />
           </div>
         </div>
         <div class="profile-info--user-bio">
           <h1 class="text-2xl font-semibold">{{ username }}</h1>
           <h2 class="text-sm text-black text-opacity-50">{{ location }}</h2>
-          <p class="text-black text-opacity-50 pt-2">{{ bio }}</p>
+          <p class="text-black text-opacity-50 pt-2 md:hidden">{{ bio }}</p>
         </div>
         <div class="profile-info--follow">
-          <CoreFollowButton :badges="badges" />
+          <CoreFollowButton />
         </div>
-        <div class="profile-info--socials">
+        <div class="profile-info--user-activity hidden md:grid">
+          <p><span class="font-semibold">Runs: </span>{{ runCount }}</p>
+          <p><span class="font-semibold">Games: </span>{{ gameCount }}</p>
+        </div>
+        <div class="profile-info--socials md:hidden">
           <CoreSocialButtons :socials="socials" />
         </div>
       </div>
@@ -62,9 +66,14 @@ export default defineComponent({
     socials: {
       default: () => [
         {
-          icon: 'twtr',
-          name: 'Twitter',
-          url: 'https://twitter.com/',
+          icon: 'dscrd',
+          name: 'Discord',
+          url: 'https://discord.com/',
+        },
+        {
+          icon: 'twch',
+          name: 'Twitch',
+          url: 'https://twitch.tv/',
         },
         {
           icon: 'twtr',
@@ -72,14 +81,9 @@ export default defineComponent({
           url: 'https://twitter.com/',
         },
         {
-          icon: 'twtr',
-          name: 'Twitter',
-          url: 'https://twitter.com/',
-        },
-        {
-          icon: 'twtr',
-          name: 'Twitter',
-          url: 'https://twitter.com/',
+          icon: 'yt',
+          name: 'Youtube',
+          url: 'https://youtube.com/',
         },
       ],
       type: Array,
@@ -99,16 +103,17 @@ export default defineComponent({
   position: relative;
 
   @apply flex flex-col;
-  @apply max-w-screen-sm;
-  @apply border border-current;
+  @apply max-w-screen-md md:max-w-full md:min-h-0 md:h-auto;
+  @apply border md:border-gray-300 md:rounded;
 }
 
 .profile-banner {
   height: 50%;
   min-height: 50%;
 
+  @apply md:h-auto md:min-h-0;
   @apply bg-cover bg-center bg-gray-900;
-  @apply flex items-center justify-center overflow-x-hidden;
+  @apply flex items-center justify-center overflow-hidden;
 }
 
 .profile-banner > img {
@@ -116,25 +121,25 @@ export default defineComponent({
 }
 
 .profile-info-container {
-  position: absolute;
-  @apply bg-transparent;
-  @apply m-5 mb-0;
+  @apply absolute md:relative bg-transparent;
+  @apply m-5 mb-0 md:m-0;
 }
 
 .profile-info {
   margin-top: 60px;
+  @apply md:mt-0 md:px-4;
 
   @apply bg-white;
-  @apply grid grid-cols-1;
-  @apply border border-gray-300 rounded;
+  @apply grid grid-cols-1 md:flex md:items-center;
+  @apply border border-gray-300 rounded md:border-none;
 }
 
 .profile-info--header {
-  @apply grid grid-rows-1 grid-cols-3 relative;
+  @apply grid grid-rows-1 grid-cols-3 md:flex relative;
 }
 
 .profile-info--picture-container {
-  @apply relative;
+  @apply relative flex justify-center;
 }
 
 .profile-info--picture-container > img {
@@ -147,8 +152,7 @@ export default defineComponent({
     max-width: 82px;
   }
 
-  @apply absolute transform -translate-y-1/2;
-  @apply rounded;
+  @apply absolute md:relative rounded transform -translate-y-1/2;
 }
 
 .profile-info--socials {
@@ -156,18 +160,22 @@ export default defineComponent({
 }
 
 .profile-info--follow > .follow-button {
-  @apply w-full;
+  @apply w-full md:px-5;
 }
 
 .profile-info--follow,
 .profile-info--user-activity,
 .profile-info--user-badges {
-  @apply p-4;
+  @apply p-4 md:pl-5 md:pr-0;
+}
+
+.profile-info--user-activity {
+  @apply md:grid-cols-2 md:gap-x-5;
 }
 
 .profile-info--user-bio {
   @apply row-span-2;
-  @apply px-4;
+  @apply px-4 md:pl-5 md:pr-0;
   @apply text-center;
 }
 </style>

--- a/components/ProfileHeader/ProfileHeader.vue
+++ b/components/ProfileHeader/ProfileHeader.vue
@@ -6,10 +6,11 @@
     <div class="profile-info-container">
       <div class="profile-info">
         <div class="profile-info--header">
-          <div class="profile-info--user-activity md:hidden">
-            <p><span class="font-semibold">Runs: </span>{{ runCount }}</p>
-            <p><span class="font-semibold">Games: </span>{{ gameCount }}</p>
-          </div>
+          <UserActivity
+            class="md:hidden"
+            :game-count="gameCount"
+            :run-count="runCount"
+          />
           <div class="profile-info--picture-container">
             <img src="https://via.placeholder.com/120" alt="profile picture" />
           </div>
@@ -25,10 +26,11 @@
         <div class="profile-info--follow">
           <CoreFollowButton />
         </div>
-        <div class="profile-info--user-activity hidden md:grid">
-          <p><span class="font-semibold">Runs: </span>{{ runCount }}</p>
-          <p><span class="font-semibold">Games: </span>{{ gameCount }}</p>
-        </div>
+        <UserActivity
+          class="hidden md:grid"
+          :game-count="gameCount"
+          :run-count="runCount"
+        />
         <div class="profile-info--socials md:hidden">
           <CoreSocialButtons :socials="socials" />
         </div>
@@ -39,8 +41,12 @@
 
 <script>
 import { defineComponent } from '@nuxtjs/composition-api';
+import UserActivity from './UserActivity/UserActivity.vue';
 
 export default defineComponent({
+  components: {
+    UserActivity,
+  },
   props: {
     badges: {
       default: () => [],

--- a/components/ProfileHeader/UserActivity/UserActivity.test.js
+++ b/components/ProfileHeader/UserActivity/UserActivity.test.js
@@ -1,0 +1,16 @@
+import { stubbedRender } from '@/testUtils';
+import UserActivity from './UserActivity';
+
+describe('<UserActivity />', () => {
+  it('should render without crashing', () => {
+    const { unmount } = stubbedRender(UserActivity);
+
+    unmount();
+  });
+
+  it('renders correctly', () => {
+    const { container } = stubbedRender(UserActivity);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/components/ProfileHeader/UserActivity/UserActivity.vue
+++ b/components/ProfileHeader/UserActivity/UserActivity.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="profile-info--user-activity" v-bind="$attrs">
+    <p><span class="font-semibold">Runs: </span>{{ runCount }}</p>
+    <p><span class="font-semibold">Games: </span>{{ gameCount }}</p>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from '@nuxtjs/composition-api';
+
+export default defineComponent({
+  props: {
+    gameCount: {
+      default: () => 6,
+      type: Number,
+    },
+    runCount: {
+      default: () => 42,
+      type: Number,
+    },
+  },
+});
+</script>

--- a/components/ProfileHeader/UserActivity/__snapshots__/UserActivity.test.js.snap
+++ b/components/ProfileHeader/UserActivity/__snapshots__/UserActivity.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<UserActivity /> renders correctly 1`] = `
+<div
+  class="profile-info--user-activity"
+>
+  <p>
+    <span
+      class="font-semibold"
+    >
+      Runs: 
+    </span>
+    42
+  </p>
+   
+  <p>
+    <span
+      class="font-semibold"
+    >
+      Games: 
+    </span>
+    6
+  </p>
+</div>
+`;

--- a/components/ProfileHeader/__snapshots__/ProfileHeader.test.js.snap
+++ b/components/ProfileHeader/__snapshots__/ProfileHeader.test.js.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ProfileHeader /> renders correctly 1`] = `
+<div
+  class="profile-header"
+>
+  <div
+    class="profile-banner"
+  >
+    <img
+      alt="profile banner"
+      src="https://via.placeholder.com/885x120"
+    />
+  </div>
+   
+  <div
+    class="profile-info-container"
+  >
+    <div
+      class="profile-info"
+    >
+      <div
+        class="profile-info--header"
+      >
+        <div
+          class="profile-info--user-activity md:hidden"
+        >
+          <p>
+            <span
+              class="font-semibold"
+            >
+              Runs: 
+            </span>
+            42
+          </p>
+           
+          <p>
+            <span
+              class="font-semibold"
+            >
+              Games: 
+            </span>
+            6
+          </p>
+        </div>
+         
+        <div
+          class="profile-info--picture-container"
+        >
+          <img
+            alt="profile picture"
+            src="https://via.placeholder.com/120"
+          />
+        </div>
+         
+        <div
+          class="profile-info--user-badges md:hidden"
+        >
+          <div
+            badges=""
+            class="user-badges--container"
+          />
+        </div>
+      </div>
+       
+      <div
+        class="profile-info--user-bio"
+      >
+        <h1
+          class="text-2xl font-semibold"
+        >
+          JohnSmithRuns
+        </h1>
+         
+        <h2
+          class="text-sm text-black text-opacity-50"
+        >
+          Olympus Mons, Mars
+        </h2>
+         
+        <p
+          class="text-black text-opacity-50 pt-2 md:hidden"
+        >
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed eget dapibus libero. Morbi ultricies varius accumsan.
+        </p>
+      </div>
+       
+      <div
+        class="profile-info--follow"
+      >
+        <button
+          class="follow-button"
+        >
+          
+  Follow
+
+        </button>
+      </div>
+       
+      <div
+        class="profile-info--user-activity hidden md:grid"
+      >
+        <p>
+          <span
+            class="font-semibold"
+          >
+            Runs: 
+          </span>
+          42
+        </p>
+         
+        <p>
+          <span
+            class="font-semibold"
+          >
+            Games: 
+          </span>
+          6
+        </p>
+      </div>
+       
+      <div
+        class="profile-info--socials md:hidden"
+      >
+        <div
+          class="social-button--container"
+        >
+          <a
+            alt="Discord"
+            class="social-button"
+            href="https://discord.com/"
+          >
+            
+    dscrd
+  
+          </a>
+          <a
+            alt="Twitch"
+            class="social-button"
+            href="https://twitch.tv/"
+          >
+            
+    twch
+  
+          </a>
+          <a
+            alt="Twitter"
+            class="social-button"
+            href="https://twitter.com/"
+          >
+            
+    twtr
+  
+          </a>
+          <a
+            alt="Youtube"
+            class="social-button"
+            href="https://youtube.com/"
+          >
+            
+    yt
+  
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/SiteNavbar/SiteNavbar.vue
+++ b/components/SiteNavbar/SiteNavbar.vue
@@ -12,8 +12,8 @@
         py-3
       "
     >
-      <NuxtLink class="flex flex-grow" to="/">
-        <div class="flex">
+      <div class="flex flex-grow">
+        <NuxtLink class="flex" to="/">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             class="h-10 w-10 mx-1"
@@ -43,8 +43,8 @@
           >
             speedrun.website
           </h1>
-        </div>
-      </NuxtLink>
+        </NuxtLink>
+      </div>
       <div
         v-show="lg || mobileNavIsActive"
         class="

--- a/components/SiteNavbar/__snapshots__/SiteNavbar.test.js.snap
+++ b/components/SiteNavbar/__snapshots__/SiteNavbar.test.js.snap
@@ -16,12 +16,12 @@ exports[`<SiteNavbar /> renders correctly 1`] = `
       py-3
     "
   >
-    <a
+    <div
       class="flex flex-grow"
-      href="/"
     >
-      <div
+      <a
         class="flex"
+        href="/"
       >
         <svg
           class="h-10 w-10 mx-1"
@@ -55,8 +55,8 @@ exports[`<SiteNavbar /> renders correctly 1`] = `
           speedrun.website
         
         </h1>
-      </div>
-    </a>
+      </a>
+    </div>
      
     <div
       class="

--- a/components/core/FollowButton/FollowButton.test.js
+++ b/components/core/FollowButton/FollowButton.test.js
@@ -1,0 +1,57 @@
+import { fireEvent, stubbedRender } from '@/testUtils';
+import FollowButton from './FollowButton';
+
+describe('<FollowButton />', () => {
+  const mockOnClick = jest.fn();
+  const defaultProps = { onClick: mockOnClick };
+
+  it('should render without crashing', () => {
+    const { unmount } = stubbedRender(FollowButton, {
+      props: defaultProps,
+    });
+
+    unmount();
+  });
+
+  it('renders correctly', () => {
+    const { container } = stubbedRender(FollowButton, {
+      props: defaultProps,
+    });
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  describe('when the onClick is initiated', () => {
+    describe('and no onClick prop is passed', () => {
+      const spyConsoleLog = jest.spyOn(console, 'log');
+
+      it('should call the default onSubmit methd', async () => {
+        const { container } = stubbedRender(FollowButton);
+
+        await fireEvent.click(container.firstChild);
+
+        expect(spyConsoleLog).toHaveBeenCalled();
+      });
+    });
+
+    test('the onClick method is called when follow button is clicked', async () => {
+      const { container } = stubbedRender(FollowButton, {
+        props: defaultProps,
+      });
+
+      await fireEvent.click(container.firstChild);
+
+      expect(mockOnClick).toHaveBeenCalled();
+    });
+
+    test('the onClick method is called when the enter key is released', async () => {
+      const { container } = stubbedRender(FollowButton, {
+        props: defaultProps,
+      });
+
+      await fireEvent.type(container.firstChild, '{enter}');
+
+      expect(mockOnClick).toHaveBeenCalled();
+    });
+  });
+});

--- a/components/core/FollowButton/FollowButton.test.js
+++ b/components/core/FollowButton/FollowButton.test.js
@@ -2,6 +2,10 @@ import { fireEvent, stubbedRender } from '@/testUtils';
 import FollowButton from './FollowButton';
 
 describe('<FollowButton />', () => {
+  /*
+   * This is a mock function for the onClick prop that is passed to the component.
+   * It is used to check a click event on the button calls the passed onClick function.
+   */
   const mockOnClick = jest.fn();
   const defaultProps = { onClick: mockOnClick };
 

--- a/components/core/FollowButton/FollowButton.vue
+++ b/components/core/FollowButton/FollowButton.vue
@@ -25,6 +25,6 @@ export default defineComponent({
 
 <style scoped>
 .follow-button {
-  @apply m-2 py-2 text-center border border-current rounded border-gray-300 rounded hover:bg-gray-100;
+  @apply px-3 py-2 text-center border border-current rounded border-gray-300 rounded hover:bg-gray-100;
 }
 </style>

--- a/components/core/FollowButton/FollowButton.vue
+++ b/components/core/FollowButton/FollowButton.vue
@@ -1,0 +1,30 @@
+<template>
+  <button
+    class="follow-button"
+    v-bind="$attrs"
+    v-on="$listeners"
+    @click="onClick"
+    @keyup.enter="onClick"
+  >
+    Follow
+  </button>
+</template>
+
+<script>
+import { defineComponent } from '@nuxtjs/composition-api';
+
+export default defineComponent({
+  props: {
+    onClick: {
+      default: () => console.log('follow'), // eslint-disable-line no-console
+      type: Function,
+    },
+  },
+});
+</script>
+
+<style scoped>
+.follow-button {
+  @apply m-2 py-2 text-center border border-current rounded border-gray-300 rounded hover:bg-gray-100;
+}
+</style>

--- a/components/core/FollowButton/__snapshots__/FollowButton.test.js.snap
+++ b/components/core/FollowButton/__snapshots__/FollowButton.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<FollowButton /> renders correctly 1`] = `
+<button
+  class="follow-button"
+>
+  
+  Follow
+
+</button>
+`;

--- a/components/core/SocialButtons/SocialButtons.test.js
+++ b/components/core/SocialButtons/SocialButtons.test.js
@@ -1,0 +1,53 @@
+import { stubbedRender } from '@/testUtils';
+import SocialButtons from './SocialButtons';
+
+describe('<SocialButtons />', () => {
+  const defaultProps = {
+    socials: [
+      {
+        icon: 'dscrd',
+        name: 'Discord',
+        url: 'https://discord.com/',
+      },
+      {
+        icon: 'twch',
+        name: 'Twitch',
+        url: 'https://twitch.tv/johnsmithruns',
+      },
+      {
+        icon: 'twtr',
+        name: 'Twitter',
+        url: 'https://twitter.com/johnsmithruns',
+      },
+    ],
+  };
+
+  it('should render without crashing', () => {
+    const { unmount } = stubbedRender(SocialButtons, {
+      props: defaultProps,
+    });
+
+    unmount();
+  });
+
+  it('renders correctly', () => {
+    const { container } = stubbedRender(SocialButtons, {
+      props: defaultProps,
+    });
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('renders the correct amount of social links', () => {
+    const { container, getByText } = stubbedRender(SocialButtons, {
+      props: defaultProps,
+    });
+
+    expect(container.firstChild.childNodes.length).toEqual(
+      defaultProps.socials.length,
+    );
+    defaultProps.socials.forEach((social) => {
+      expect(getByText(social.icon)).toBeInTheDocument();
+    });
+  });
+});

--- a/components/core/SocialButtons/SocialButtons.vue
+++ b/components/core/SocialButtons/SocialButtons.vue
@@ -1,0 +1,3 @@
+<template>
+  <div class="social-button--container"></div>
+</template>

--- a/components/core/SocialButtons/SocialButtons.vue
+++ b/components/core/SocialButtons/SocialButtons.vue
@@ -1,3 +1,39 @@
 <template>
-  <div class="social-button--container"></div>
+  <div class="social-button--container">
+    <a
+      v-for="social in socials"
+      :key="social.name"
+      class="social-button"
+      :alt="social.name"
+      :href="social.url"
+    >
+      {{ social.icon }}
+    </a>
+  </div>
 </template>
+
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api';
+
+export default defineComponent({
+  props: {
+    socials: {
+      required: true,
+      type: Array,
+    },
+  },
+});
+</script>
+
+<style scoped>
+.social-button--container {
+  @apply my-1;
+  @apply grid auto-cols-fr grid-cols-4 gap-3;
+}
+
+.social-button {
+  @apply flex content-center items-center justify-center justify-items-center;
+  @apply rounded bg-gray-100;
+  @apply p-2;
+}
+</style>

--- a/components/core/SocialButtons/__snapshots__/SocialButtons.test.js.snap
+++ b/components/core/SocialButtons/__snapshots__/SocialButtons.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SocialButtons /> renders correctly 1`] = `
+<div
+  class="social-button--container"
+>
+  <a
+    alt="Discord"
+    class="social-button"
+    href="https://discord.com/"
+  >
+    
+    dscrd
+  
+  </a>
+  <a
+    alt="Twitch"
+    class="social-button"
+    href="https://twitch.tv/johnsmithruns"
+  >
+    
+    twch
+  
+  </a>
+  <a
+    alt="Twitter"
+    class="social-button"
+    href="https://twitter.com/johnsmithruns"
+  >
+    
+    twtr
+  
+  </a>
+</div>
+`;

--- a/components/core/UserBadges/UserBadges.test.js
+++ b/components/core/UserBadges/UserBadges.test.js
@@ -1,0 +1,16 @@
+import { stubbedRender } from '@/testUtils';
+import UserBadges from './UserBadges';
+
+describe('<ProfileHeader />', () => {
+  it('should render without crashing', () => {
+    const { unmount } = stubbedRender(UserBadges);
+
+    unmount();
+  });
+
+  it('renders correctly', () => {
+    const { container } = stubbedRender(UserBadges);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/components/core/UserBadges/UserBadges.vue
+++ b/components/core/UserBadges/UserBadges.vue
@@ -1,0 +1,3 @@
+<template>
+  <div class="user-badges--container"></div>
+</template>

--- a/components/core/UserBadges/UserBadges.vue
+++ b/components/core/UserBadges/UserBadges.vue
@@ -1,3 +1,8 @@
+<!--
+  This is just a placeholder component for now,
+  and will be properly defined later on.
+-->
+
 <template>
   <div class="user-badges--container"></div>
 </template>

--- a/components/core/UserBadges/__snapshots__/UserBadges.test.js.snap
+++ b/components/core/UserBadges/__snapshots__/UserBadges.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ProfileHeader /> renders correctly 1`] = `
+<div
+  class="user-badges--container"
+/>
+`;


### PR DESCRIPTION
## What
Create a `<ProfileHeader />` component for  the profile page that'll be built out eventually. Also built out some sub components, that'll be reused later, and some placeholder components.

## Link to Issue
Resolves https://github.com/speedrun-website/speedrun.website/issues/10

## Acceptance
### Steps for testing

- Checkout the PR and add it to a page, in order to see it in action

### Images

| • | Landscape | Portrait |
| --- | --- | --- |
| Mobile | ![Screen Shot 2021-08-16 at 09 01 39](https://user-images.githubusercontent.com/17736056/129568154-038f2166-5447-4ebd-ab92-988d7e9185c9.png) ![Screen Shot 2021-08-16 at 09 01 42](https://user-images.githubusercontent.com/17736056/129568200-f13b7b48-ed9f-40e4-bed4-f53ef1c4e2c5.png) | ![Screen Shot 2021-08-16 at 09 01 23](https://user-images.githubusercontent.com/17736056/129568122-291c4c82-58bb-4126-aad4-c8c4e14083be.png) |
| Tablet | ![Screen Shot 2021-08-16 at 09 02 04](https://user-images.githubusercontent.com/17736056/129568286-e4ef2b02-ef39-4fa7-8aa3-425d37e5bda4.png) | ![Screen Shot 2021-08-16 at 09 02 02](https://user-images.githubusercontent.com/17736056/129568269-49b682bb-5088-47f7-9dcf-fc3f725745ff.png) |
| Desktop | ![Screen Shot 2021-08-16 at 09 02 18](https://user-images.githubusercontent.com/17736056/129568303-0c2bc663-4f47-4125-9709-b4757647beaa.png) | ![Screen Shot 2021-08-16 at 09 03 31](https://user-images.githubusercontent.com/17736056/129568323-6262545a-a07d-4836-b91d-729a8f215571.png) |


